### PR TITLE
keep the 'records' dialog shown in the viewport

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -5,6 +5,7 @@ import { Modal, ModalHeader, ModalBody } from 'reactstrap';
 import DTable, { CELL_TYPE, FORMULA_RESULT_TYPE } from 'dtable-sdk';
 import Settings from './components/settings';
 import TableView from './components/table-view';
+import DetailDuplicationDialog from './components/detail-duplication-dialog';
 import DeleteTip from './components/tips/delete-tip';
 import { compareString, throttle, getSelectColumnOptionMap } from './utils';
 import CellValueUtils from './utils/cell-value-utils';
@@ -48,7 +49,8 @@ class App extends React.Component {
       allDeDuplicationColumns: [],
       pageSize: 1,
       selectedItem: {},
-      duplicationData: {}
+      duplicationData: {},
+      expandedRowIndex: -1
     };
     this.dtable = new DTable();
     this.cellValueUtils = new CellValueUtils({ dtable: this.dtable });
@@ -526,8 +528,29 @@ class App extends React.Component {
     this.innerTableHeight = height;
   }
 
+  getExpandRowItem = () => {
+    const { expandedRowIndex, duplicationRows } = this.state;
+    const duplicationRow = duplicationRows[expandedRowIndex];
+    const { rows = [] } = duplicationRow || {};
+    const rowsSelected = rows.map(item => false);
+    return {
+      rows,
+      rowsSelected,
+      value: rows.length,
+      isAllSelected: false,
+    };
+  }
+
+  onHideExpandRow = () => {
+    this.setState({expandedRowIndex: -1});
+  }
+
+  setExpandedRowIndex = (index) => {
+    this.setState({expandedRowIndex: index});
+  }
+
   render() {
-    let { showDialog, configSettings, duplicationRows, allDeDuplicationColumns, isDeleteTipShow, pageSize } = this.state;
+    let { expandedRowIndex, showDialog, configSettings, duplicationRows, allDeDuplicationColumns, isDeleteTipShow, pageSize } = this.state;
     return (
       <Fragment>
         <Modal
@@ -564,16 +587,11 @@ class App extends React.Component {
                       <TableView
                         duplicationRows={duplicationRows.slice(0, pageSize * 50)}
                         allDeDuplicationColumns={allDeDuplicationColumns}
-                        configSettings={configSettings}
+                        setExpandedRowIndex={this.setExpandedRowIndex}
                         collaborators={this.collaborators}
-                        dtable={this.dtable}
-                        onDeleteRow={this.onDeleteRow}
-                        onDeleteSelectedRows={this.deleteRowsByIds}
                         setTableHeight={this.setTableHeight}
                         formulaRows={this.state.formulaRows}
                         getUserCommonInfo={this.getUserCommonInfo}
-                        getOptionColors={this.getOptionColors}
-                        getCellValueDisplayString={this.getCellValueDisplayString}
                         getMediaUrl={this.getMediaUrl}
                       />
                     </div>
@@ -584,6 +602,23 @@ class App extends React.Component {
                   />
                 </div>
               )}
+            {expandedRowIndex > -1 && (
+              <DetailDuplicationDialog
+                selectedItem={this.getExpandRowItem()}
+                onHideExpandRow={this.onHideExpandRow}
+                configSettings={configSettings}
+                collaborators={this.collaborators}
+                dtable={this.dtable}
+                onDeleteRow={this.onDeleteRow}
+                onDeleteSelectedRows={this.deleteRowsByIds}
+                setTableHeight={this.setTableHeight}
+                formulaRows={this.state.formulaRows}
+                getUserCommonInfo={this.getUserCommonInfo}
+                getOptionColors={this.getOptionColors}
+                getCellValueDisplayString={this.getCellValueDisplayString}
+                getMediaUrl={this.getMediaUrl}
+              />
+            )}
           </ModalBody>
         </Modal>
       </Fragment>

--- a/src/components/table-view.js
+++ b/src/components/table-view.js
@@ -1,21 +1,13 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import intl from 'react-intl-universal';
 import { CELL_TYPE } from 'dtable-sdk';
-import DetailDuplicationDialog from './detail-duplication-dialog';
 import { getSelectColumnOptionMap } from '../utils';
 import Formatter from './formatter';
 
 import styles from '../css/plugin-layout.module.css';
 
 class TableView extends React.Component {
-
-  constructor(props) {
-    super(props);
-    this.state = {
-      expandRowIndex: -1,
-    };
-  }
 
   componentDidMount() {
     this.setTableHeight();
@@ -25,7 +17,7 @@ class TableView extends React.Component {
     const prevDuplicationRows = prevProps.duplicationRows || [];
     const currDuplicationRows = this.props.duplicationRows || [];
     if (currDuplicationRows.length !== prevDuplicationRows.length) {
-      this.setState({expandRowIndex: -1});
+      this.props.setExpandedRowIndex(-1);
     }
     this.setTableHeight();
   }
@@ -100,56 +92,21 @@ class TableView extends React.Component {
   }
 
   onExpandDuplicationRow = (rowIndex) => {
-    this.setState({expandRowIndex: rowIndex});
-  }
-
-  getExpandRowItem = () => {
-    const { expandRowIndex } = this.state;
-    const duplicationRow = this.props.duplicationRows[expandRowIndex];
-    const { rows = [] } = duplicationRow || {};
-    const rowsSelected = rows.map(item => false);
-    return {
-      rows,
-      rowsSelected,
-      value: rows.length,
-      isAllSelected: false,
-    };
-  }
-
-  onHideExpandRow = () => {
-    this.setState({expandRowIndex: -1});
+    this.props.setExpandedRowIndex(rowIndex);
   }
 
   render() {
-    const { expandRowIndex } = this.state;
-    const { duplicationRows, configSettings } = this.props;
+    const { duplicationRows } = this.props;
     if (!Array.isArray(duplicationRows) ||  duplicationRows.length === 0) {
       return <div className={styles['error-description']}>{intl.get('No_duplication')}</div>;
     } else {
       return (
-        <Fragment>
-          <table ref={(ref) => this.tableContainer = ref} className="deduplicate-table-container">
-            {this.renderHeader()}
-            <tbody>
-              {this.renderBody()}
-            </tbody>
-          </table>
-          {expandRowIndex > -1 && (
-            <DetailDuplicationDialog
-              selectedItem={this.getExpandRowItem()}
-              configSettings={configSettings}
-              collaborators={this.props.collaborators}
-              dtable={this.props.dtable}
-              onDeleteRow={this.props.onDeleteRow}
-              onDeleteSelectedRows={this.props.onDeleteSelectedRows}
-              onHideExpandRow={this.onHideExpandRow}
-              formulaRows={this.props.formulaRows}
-              getOptionColors={this.props.getOptionColors}
-              getCellValueDisplayString={this.props.getCellValueDisplayString}
-              getMediaUrl={this.props.getMediaUrl}
-            />
-          )}
-        </Fragment>
+        <table ref={(ref) => this.tableContainer = ref} className="deduplicate-table-container">
+          {this.renderHeader()}
+          <tbody>
+            {this.renderBody()}
+          </tbody>
+        </table>
       );
     }
   }
@@ -159,11 +116,7 @@ TableView.propTypes = {
   formulaRows: PropTypes.object,
   duplicationRows: PropTypes.array,
   allDeDuplicationColumns: PropTypes.array,
-  configSettings: PropTypes.array,
   collaborators: PropTypes.array,
-  dtable: PropTypes.object,
-  onDeleteRow: PropTypes.func,
-  onDeleteSelectedRows: PropTypes.func,
   setTableHeight: PropTypes.func,
   getUserCommonInfo: PropTypes.func,
   getMediaUrl: PropTypes.func

--- a/src/css/plugin-layout.module.css
+++ b/src/css/plugin-layout.module.css
@@ -120,8 +120,8 @@
   position: absolute;
   z-index: 10;
   top: 10%;
-  left: 25%;
-  width: 50%;
+  left: 17.5%;
+  width: 35%;
   height: 80%;
   max-height: 500px;
   flex-shrink: 0;


### PR DESCRIPTION
- after scrolling the 'deduplication' table & clicking a cell in the
'Count' columnn, display the 'records' dialog in the viewport